### PR TITLE
added system architecture flag

### DIFF
--- a/cpu2.c
+++ b/cpu2.c
@@ -1,6 +1,8 @@
 #ifndef PROCESSOR_H
 #define PROCESSOR_H
 
+#define _CPUx64
+
 class controls
 {
 private:


### PR DESCRIPTION
Added system architecture flag that detect which is the word size of operating system x64 or x86